### PR TITLE
rhine: build keystore

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -132,6 +132,9 @@ PRODUCT_PACKAGES += \
     wpa_supplicant \
     wpa_supplicant.conf
 
+PRODUCT_PACKAGES += \
+    keystore.msm8974
+
 #Misc
 PRODUCT_PACKAGES += \
     libmiscta \


### PR DESCRIPTION
you need to add these five binaries:
	vendor/firmware/keymaster/keymaster.b00
	vendor/firmware/keymaster/keymaster.b01
	vendor/firmware/keymaster/keymaster.b02
	vendor/firmware/keymaster/keymaster.b03
	vendor/firmware/keymaster/keymaster.mdt