### PR TITLE
mkqcdtbootimg:  --dt_version 2

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -35,7 +35,7 @@ BOARD_RAMDISK_OFFSET     := 0x02000000
 BOARD_KERNEL_BOOTIMG := true
 BOARD_CUSTOM_MKBOOTIMG := mkqcdtbootimg
 BOARD_MKBOOTIMG_ARGS := --ramdisk_offset $(BOARD_RAMDISK_OFFSET) --tags_offset $(BOARD_KERNEL_TAGS_OFFSET)
-BOARD_MKBOOTIMG_ARGS += --dt_dir $(OUT)/dtbs
+BOARD_MKBOOTIMG_ARGS += --dt_dir $(OUT)/dtbs --dt_version 2
 
 BOARD_KERNEL_CMDLINE := androidboot.hardware=rhine user_debug=31 maxcpus=2 msm_rtb.filter=0x3F ehci-hcd.park=3 lpj=192598
 BOARD_KERNEL_CMDLINE += dwc3.maximum_speed=high dwc3_msm.prop_chg_detect=Y console=ttyHSL0,115200,n8


### PR DESCRIPTION
rhine was upgraded to v2 in 3.10 kernel

Signed-off-by: Adam Farden <adam@farden.cz>