### PR TITLE
rhine: remove TARGET_CPU_SMP flag

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -20,7 +20,6 @@ TARGET_BOARD_PLATFORM = msm8974
 TARGET_CPU_ABI := armeabi-v7a
 TARGET_CPU_ABI2 := armeabi
 TARGET_CPU_VARIANT := krait
-TARGET_CPU_SMP := true
 TARGET_GLOBAL_CFLAGS += -mfpu=neon -mfloat-abi=softfp
 TARGET_GLOBAL_CPPFLAGS += -mfpu=neon -mfloat-abi=softfp
 TARGET_NO_RADIOIMAGE := true


### PR DESCRIPTION
* TARGET_CPU_SMP defaults to true in Lollipop

Signed-off-by: Brin Taylor <uberlaggydarwin@gmail.com>