### PR TITLE
[RHINE] init: Remove I/O scheduler changes. Follow kernel defaults.

### DIFF
--- a/rootdir/init.rhine.pwr.rc
+++ b/rootdir/init.rhine.pwr.rc
@@ -143,9 +143,3 @@ on property:init.svc.bootanim=stopped
     write /sys/module/cpu_boost/parameters/input_boost_ms 40
     write /sys/class/kgsl/kgsl-3d0/devfreq/governor msm-adreno-tz
     write /dev/cpuctl/apps/cpu.notify_on_migrate 1
-
-    write /sys/block/mmcblk0/queue/scheduler row
-
-on property:init.svc.bootanim=running
-    # Switch to NOOP while booting
-    write /sys/block/mmcblk0/queue/scheduler noop

--- a/rootdir/init.rhine.rc
+++ b/rootdir/init.rhine.rc
@@ -17,8 +17,6 @@ import init.rhine.pwr.rc
 
 on early-init
     mount debugfs debugfs /sys/kernel/debug
-    write /sys/block/mmcblk0/queue/scheduler noop
-    write /sys/block/mmcblk0/bdi/read_ahead_kb 512
 
 on init
     mkdir /tmp


### PR DESCRIPTION
While this may be good when booting the system, it's actually really
bad for kernel. Remove lines that will mess with the I/O scheduler
and its configuration to follow kernel defaults.