### PR TITLE
init.rhine.pwr.rc: bump go_hispeed_load to 99

### DIFF
--- a/rootdir/init.rhine.pwr.rc
+++ b/rootdir/init.rhine.pwr.rc
@@ -125,7 +125,7 @@ on property:init.svc.bootanim=stopped
     write /sys/devices/system/cpu/cpu3/cpufreq/scaling_governor "interactive"
     write /sys/module/msm_thermal/core_control/enabled 1
     write /sys/devices/system/cpu/cpufreq/interactive/above_hispeed_delay "20000 1400000:40000 1700000:20000"
-    write /sys/devices/system/cpu/cpufreq/interactive/go_hispeed_load 90
+    write /sys/devices/system/cpu/cpufreq/interactive/go_hispeed_load 99
     write /sys/devices/system/cpu/cpufreq/interactive/hispeed_freq 1190400
     write /sys/devices/system/cpu/cpufreq/interactive/io_is_busy 1
     write /sys/devices/system/cpu/cpufreq/interactive/target_loads "85 1500000:90 1800000:70"


### PR DESCRIPTION
* This saves more juice, and doesn't influence performance.