### PR TITLE
Revert "rhine: fix cmdline permission"

### DIFF
--- a/rootdir/init.rhine.rc
+++ b/rootdir/init.rhine.rc
@@ -17,7 +17,6 @@ import init.rhine.pwr.rc
 
 on early-init
     mount debugfs debugfs /sys/kernel/debug
-    chmod 644 /proc/cmdline
 
 on init
     mkdir /tmp


### PR DESCRIPTION
Reverts sonyxperiadev/device-sony-rhine#42

It *should* not be world readable, as it contains the IMEI and serial number.