### PR TITLE
rhine: Fix video nodes permission

### DIFF
--- a/rootdir/ueventd.rhine.rc
+++ b/rootdir/ueventd.rhine.rc
@@ -76,6 +76,8 @@
 /dev/ttyGS0               0660   system     system
 /dev/i2c-5                0660   media      media
 /dev/voice_svc            0660   system     audio
+/dev/video32              0660   system     camera
+/dev/video33              0660   system     camera
 /sys/devices/virtual/smdpkt/smdcntl* open_timeout 0664 radio  radio
 
 # BT


### PR DESCRIPTION
needed by libqdutils and libqdMetaData

will be needed too for camera in future

Signed-off-by: David Viteri <davidteri91@gmail.com>