### PR TITLE
rhine: remove overrides packages

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -176,9 +176,6 @@ PRODUCT_PACKAGES += \
     com.android.future.usb.accessory
 
 PRODUCT_PACKAGES += \
-    Dialer \
-    Email \
-    Exchange2 \
     InCallUI \
     Launcher3
 


### PR DESCRIPTION
Honami, Amami and Togari are calling: aosp_base.mk
                                      telephony.mk

in AOSP telephony.mk is calling (Dialer): https://android.googlesource.com/platform/build/+/android-5.1.0_r3/target/product/telephony.mk

in AOSP aosp_base.mk calls others .mk as core.mk who is calling (Email and Exchange2) (Strings 35 and 36): https://android.googlesource.com/platform/build/+/android-5.1.0_r3/target/product/core.mk

Signed-off-by: David Viteri <davidteri91@gmail.com>