### PR TITLE
rhine: Enable LTE

### DIFF
--- a/overlay/packages/services/Telephony/res/values/config.xml
+++ b/overlay/packages/services/Telephony/res/values/config.xml
@@ -32,6 +32,9 @@
     <!-- Flag indicating if dtmf tone type is enabled -->
     <bool name="dtmf_type_enabled">true</bool>
 
+    <!-- Show enabled lte option for lte device -->
+    <bool name="config_enabled_lte" translatable="false">true</bool>
+
     <!-- Determine whether we should show the "listen for instructions" screen after
          successfully placing the OTA call -->
     <integer name="OtaShowListeningScreen">1</integer>


### PR DESCRIPTION
also telephony.lteOnGsmDevice=1 is set in system.prop

Signed-off-by: David Viteri <davidteri91@gmail.com>