### PR TITLE
rhine: remove double LTE prop

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -24,7 +24,6 @@ telephony.lteOnCdmaDevice=0
 telephony.lteOnGSMDevice=1
 wifi.interface=wlan0
 ro.telephony.call_ring.multiple=false
-telephony.lteOnGsmDevice=1
 ro.ril.transmitpower=true
 persist.radio.add_power_save=1
 persist.radio.apm_sim_not_pwdn=1


### PR DESCRIPTION
Signed-off-by: David Viteri <davidteri91@gmail.com>