### PR TITLE
rhine: set Num of surface buffers to 3

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -56,6 +56,7 @@ TARGET_USES_C2D_COMPOSITION := true
 MAX_EGL_CACHE_KEY_SIZE := 12*1024
 MAX_EGL_CACHE_SIZE := 2048*1024
 OVERRIDE_RS_DRIVER := libRSDriver_adreno.so
+NUM_FRAMEBUFFER_SURFACE_BUFFERS := 3
 BOARD_EGL_CFG := device/sony/rhine/rootdir/system/lib/egl/egl.cfg
 
 # Audio


### PR DESCRIPTION
Currently, the FrameBuffer in AOSP is double-buffering.
That's bad in cases when Compositor takes time near 16ms or less.
There're so many blockers('WaitForever') in several composition periods which makes janks. While we make it triple-buffering, those blockers disappear

Signed-off-by: David Viteri <davidteri91@gmail.com>