### PR TITLE
device.mk: Don't build libgenlock

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -102,7 +102,6 @@ PRODUCT_PACKAGES += \
     copybit.msm8974 \
     hwcomposer.msm8974 \
     memtrack.msm8974 \
-    libgenlock \
     libqdutils \
     libqdMetaData
 


### PR DESCRIPTION
Removed since dinosaur age:
https://android.googlesource.com/platform/hardware/qcom/display/+/83b98f3b7c3c458707c95b854a3669c98d28d1f5
https://android.googlesource.com/platform/hardware/qcom/display/+/869ba57828f97e0b3cf8e1413b3f15248888f114