### PR TITLE
rhine: Fix path to cpuctl

### DIFF
--- a/rootdir/init.rhine.pwr.rc
+++ b/rootdir/init.rhine.pwr.rc
@@ -77,8 +77,8 @@ on boot
     chmod 0660 /sys/module/cpu_boost/parameters/input_boost_freq
     chown system system /sys/module/cpu_boost/parameters/input_boost_ms
     chmod 0660 /sys/module/cpu_boost/parameters/input_boost_ms
-    chown system system /dev/cpuctl/apps/cpu.notify_on_migrate
-    chmod 0660 /dev/cpuctl/apps/cpu.notify_on_migrate
+    chown system system /dev/cpuctl/cpu.notify_on_migrate
+    chmod 0660 /dev/cpuctl/cpu.notify_on_migrate
     chown root system /sys/devices/system/cpu/cpu1/online
     chown root system /sys/devices/system/cpu/cpu2/online
     chown root system /sys/devices/system/cpu/cpu3/online
@@ -142,4 +142,4 @@ on property:init.svc.bootanim=stopped
     write /sys/module/cpu_boost/parameters/input_boost_freq 1497600
     write /sys/module/cpu_boost/parameters/input_boost_ms 40
     write /sys/class/kgsl/kgsl-3d0/devfreq/governor msm-adreno-tz
-    write /dev/cpuctl/apps/cpu.notify_on_migrate 1
+    write /dev/cpuctl/cpu.notify_on_migrate 1


### PR DESCRIPTION
the correct path is /dev/cpuctl/cpu.notify_on_migrate not /dev/cpuctl/apps/cpu.notify_on_migrate

Signed-off-by: David Viteri <davidteri91@gmail.com>