### PR TITLE
rhine: ramdisk: fix for video nodes

### DIFF
--- a/rootdir/init.rhine.rc
+++ b/rootdir/init.rhine.rc
@@ -197,16 +197,15 @@ on boot
 
     # Remove write permissions to video related nodes
     chown system graphics /sys/class/graphics/fb1/hpd
-    chown system graphics /sys/class/graphics/fb1/hdcp/tp
-    chown system graphics /sys/class/graphics/fb1/vendor_name
     chown system graphics /sys/class/graphics/fb1/product_description
+    chown system graphics /sys/class/graphics/fb1/vendor_name
+    chown system graphics /sys/class/graphics/fb1/video_mode
+    chown system graphics /sys/class/graphics/fb1/hdcp/tp
     chmod 0664 /sys/class/graphics/fb1/hpd
-    chmod 0664 /sys/class/graphics/fb1/hdcp/tp
-    chmod 0664 /sys/class/graphics/fb1/vendor_name
     chmod 0664 /sys/class/graphics/fb1/product_description
+    chmod 0664 /sys/class/graphics/fb1/vendor_name
     chmod 0664 /sys/class/graphics/fb1/video_mode
-    chmod 0664 /sys/class/graphics/fb1/format_3d
-    chown system system /sys/class/graphics/fb1/format_3d
+    chmod 0664 /sys/class/graphics/fb1/hdcp/tp
 
     #For bridgemgr daemon to inform the USB driver of the correct transport
     chown radio radio /sys/class/android_usb/f_rmnet_smd_sdio/transport

--- a/rootdir/ueventd.rhine.rc
+++ b/rootdir/ueventd.rhine.rc
@@ -112,8 +112,8 @@
 
 /sys/devices/virtual/graphics/fb1/hpd                 0664 system graphics
 /sys/devices/virtual/graphics/fb1/video_mode          0664 system graphics
-/sys/devices/virtual/graphics/fb1/format_3d           0664 system system
 /sys/devices/virtual/graphics/fb1/vendor_name         0664 system graphics
 /sys/devices/virtual/graphics/fb1/product_description 0664 system graphics
+/sys/devices/virtual/graphics/fb1/hdcp/tp             0644 system graphics
 /sys/devices/sony_camera_0/info                       0666 camera camera
 /sys/devices/sony_camera_1/info                       0666 camera camera


### PR DESCRIPTION
deleted not exist format_3d: ls -l /sys/class/graphics/fb1/format_3d: No such file or directory
Add missing chown system graphics /sys/class/graphics/fb1/video_mode (init.rhine.rc)
Add missing /sys/devices/virtual/graphics/fb1/hdcp/tp (ueventd.rhine.rc)

Signed-off-by: David Viteri <davidteri91@gmail.com>