### PR TITLE
rhine: fix permission for video node

### DIFF
--- a/rootdir/ueventd.rhine.rc
+++ b/rootdir/ueventd.rhine.rc
@@ -114,6 +114,6 @@
 /sys/devices/virtual/graphics/fb1/video_mode          0664 system graphics
 /sys/devices/virtual/graphics/fb1/vendor_name         0664 system graphics
 /sys/devices/virtual/graphics/fb1/product_description 0664 system graphics
-/sys/devices/virtual/graphics/fb1/hdcp/tp             0644 system graphics
+/sys/devices/virtual/graphics/fb1/hdcp/tp             0664 system graphics
 /sys/devices/sony_camera_0/info                       0666 camera camera
 /sys/devices/sony_camera_1/info                       0666 camera camera


### PR DESCRIPTION
introduced in commit: b6dbc4ef9f4912b6425a0f3c410612be3952711e

Signed-off-by: David Viteri <davidteri91@gmail.com>