### PR TITLE
rhine: update ueventd

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -57,7 +57,6 @@ MAX_EGL_CACHE_KEY_SIZE := 12*1024
 MAX_EGL_CACHE_SIZE := 2048*1024
 OVERRIDE_RS_DRIVER := libRSDriver_adreno.so
 NUM_FRAMEBUFFER_SURFACE_BUFFERS := 3
-BOARD_EGL_CFG := device/sony/rhine/rootdir/system/lib/egl/egl.cfg
 
 # Audio
 BOARD_USES_ALSA_AUDIO := true

--- a/device.mk
+++ b/device.mk
@@ -49,6 +49,8 @@ PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/android.hardware.sensor.gyroscope.xml:system/etc/permissions/android.hardware.sensor.gyroscope.xml \
     frameworks/native/data/etc/android.hardware.sensor.light.xml:system/etc/permissions/android.hardware.sensor.light.xml \
     frameworks/native/data/etc/android.hardware.sensor.proximity.xml:system/etc/permissions/android.hardware.sensor.proximity.xml \
+    frameworks/native/data/etc/android.hardware.sensor.stepcounter.xml:system/etc/permissions/android.hardware.sensor.stepcounter.xml \
+    frameworks/native/data/etc/android.hardware.sensor.stepdetector.xml:system/etc/permissions/android.hardware.sensor.stepdetector.xml \
     frameworks/native/data/etc/android.hardware.telephony.gsm.xml:system/etc/permissions/android.hardware.telephony.gsm.xml \
     frameworks/native/data/etc/android.hardware.touchscreen.multitouch.jazzhand.xml:system/etc/permissions/android.hardware.touchscreen.multitouch.jazzhand.xml \
     frameworks/native/data/etc/android.hardware.usb.accessory.xml:system/etc/permissions/android.hardware.usb.accessory.xml \

--- a/rootdir/system/lib/egl/egl.cfg
+++ b/rootdir/system/lib/egl/egl.cfg
@@ -1,2 +1,0 @@
-0 0 android
-0 1 adreno

--- a/rootdir/ueventd.rhine.rc
+++ b/rootdir/ueventd.rhine.rc
@@ -74,7 +74,6 @@
 /dev/sdio_tty_ciq_00      0660   system     system
 /dev/tty_sdio_00          0660   system     system
 /dev/ttyGS0               0660   system     system
-/dev/i2c-5                0660   media      media
 /dev/voice_svc            0660   system     audio
 /dev/video32              0660   system     camera
 /dev/video33              0660   system     camera
@@ -93,9 +92,8 @@
 /dev/wcnss_ctrl           0660   system     system
 
 # NFC
-/dev/nfc-nci              0660   nfc        nfc
+/dev/i2c-2                0660   nfc        nfc
 /dev/pn544                0660   nfc        nfc
-/dev/pn547                0660   nfc        nfc
 
 # LED
 /sys/devices/01-qcom,leds-d000/leds/led:* max_brightness          0644 root system


### PR DESCRIPTION
remove not exist i2c-5 ?????
remove uneeded nfc paths and set pn544 and i2c-2 for it

Signed-off-by: David Viteri <davidteri91@gmail.com>