### PR TITLE
Tweak

### DIFF
--- a/rootdir/init.rhine.rc
+++ b/rootdir/init.rhine.rc
@@ -429,14 +429,14 @@ service iprenew_bt-pan /system/bin/dhcpcd -n
     disabled
     oneshot
 
-service sdcard /system/bin/sdcard -u 1023 -g 1023 -l /data/media /mnt/shell/emulated
+service sdcard /system/bin/sdcard -u 1023 -g 1023 -t 4 -l /data/media /mnt/shell/emulated
     class late_start
 
-service fuse_sdcard1 /system/bin/sdcard -u 1023 -g 1023 -w 1023 -d /mnt/media_rw/sdcard1 /storage/sdcard1
+service fuse_sdcard1 /system/bin/sdcard -u 1023 -g 1023 -w 1023 -t 4 -d /mnt/media_rw/sdcard1 /storage/sdcard1
     class late_start
     disabled
 
-service fuse_usbdisk /system/bin/sdcard -u 1023 -g 1023 -w 1023 -d /mnt/media_rw/usbdisk /storage/usbdisk
+service fuse_usbdisk /system/bin/sdcard -u 1023 -g 1023 -w 1023 -t 4 -d /mnt/media_rw/usbdisk /storage/usbdisk
     class late_start
     disabled
 

--- a/rootdir/init.rhine.rc
+++ b/rootdir/init.rhine.rc
@@ -144,6 +144,11 @@ on early-boot
     setrlimit 8 67108864 67108864
 
 on boot
+
+    # read ahead buffer
+    write /sys/block/mmcblk0/queue/read_ahead_kb 2048
+    write /sys/block/mmcblk1/queue/read_ahead_kb 2048
+
     # PM8941 flash
     chown media system /sys/class/misc/pm8941-flash/device/current1
     chown media system /sys/class/misc/pm8941-flash/device/current2


### PR DESCRIPTION
rhine: init: Use more thread on Fuse daemon

Use more thread to make Fuse faster.
Fuse is a user pace daemon so using more threads means that
it will handle more requests in parallel.

Increase fuse services from 2 (default) to 4 threads by using
-t as service parameter.

Test Example:

N Threads: (2)
--------------------------------------------------------------------
root@leo:# dd if=/dev/zero of=/sdcard/testfile bs=268435456 count=1
1+0 records in
1+0 records out
268435456 bytes transferred in 5.670 secs (47343113 bytes/sec)

N Threads: (4)
--------------------------------------------------------------------
root@leo:# dd if=/dev/zero of=/sdcard/testfile bs=268435456 count=1
1+0 records in
1+0 records out
268435456 bytes transferred in 5.553 secs (48340618 bytes/sec)

N Threads: (8)
--------------------------------------------------------------------
root@leo:# dd if=/dev/zero of=/sdcard/testfile bs=268435456 count=1
1+0 records in
1+0 records out
268435456 bytes transferred in 5.517 secs (48656055 bytes/sec)

===================================================================

rhine: init: Tweak mmcblk* read ahead buffer

Increase the read ahead buffer size from 1536KB
to 2MB, that brings about ≃ 15% read speed up.

Test Example
Using Fuse service with 4 threads

  Before:
  ======

root@leo:# dd if=/dev/zero of=/sdcard/testfile bs=268435456 count=1
1+0 records in
1+0 records out
268435456 bytes transferred in 5.553 secs (48340618 bytes/sec)

  Using this patch:
  ================

root@leo:# dd if=/dev/zero of=/sdcard/testfile bs=268435456 count=1
1+0 records in
1+0 records out
268435456 bytes transferred in 5.175 secs (51871585 bytes/sec)