### PR TITLE
Art

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -99,7 +99,9 @@ TARGET_SYSTEM_PROP := device/sony/rhine/system.prop
 EXTENDED_FONT_FOOTPRINT := true
 
 # Enable dex-preoptimization to speed up first boot sequence
-WITH_DEXPREOPT := true
+ifeq ($(HOST_OS),linux)
+    WITH_DEXPREOPT ?= true
+endif
 
 BUILD_KERNEL := true
 -include vendor/sony/kernel/KernelConfig.mk

--- a/device.mk
+++ b/device.mk
@@ -197,6 +197,21 @@ PRODUCT_COPY_FILES += device/sample/etc/apns-full-conf.xml:system/etc/apns-conf.
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.qualcomm.bt.hci_transport=smd
 
+# ART
+PRODUCT_PROPERTY_OVERRIDES += \
+    dalvik.vm.dex2oat-Xms=64m \
+    dalvik.vm.dex2oat-Xmx=512m \
+    dalvik.vm.image-dex2oat-Xms=64m \
+    dalvik.vm.image-dex2oat-Xmx=64m \
+    dalvik.vm.dex2oat-filter=speed \
+    dalvik.vm.image-dex2oat-filter=speed
+
+# ART
+PRODUCT_DEX_PREOPT_DEFAULT_FLAGS := \
+    --compiler-filter=speed
+
+$(call add-product-dex-preopt-module-config,services,--compiler-filter=speed)
+
 # Platform specific default properties
 #
 PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
rhine: Check host for Dalvik preoptimization
Turn ON Dalvik preoptimization if the build is running on Linux hosts
(since host Dalvik isn't built for non-Linux hosts)

-------------------------------------------------------------------------------------------
rhine: Add ART dex2oat controls
These values are present at stock version.
Also, set compiler-filter as "speed" which compiles most methods and
maximizes runtime performance.