### PR TITLE
rhine: remove duplicate art values

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -198,11 +198,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.qualcomm.bt.hci_transport=smd
 
 # ART
-PRODUCT_PROPERTY_OVERRIDES += \
-    dalvik.vm.dex2oat-Xms=64m \
-    dalvik.vm.dex2oat-Xmx=512m \
-    dalvik.vm.image-dex2oat-Xms=64m \
-    dalvik.vm.image-dex2oat-Xmx=64m \
+PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
     dalvik.vm.dex2oat-filter=speed \
     dalvik.vm.image-dex2oat-filter=speed
 


### PR DESCRIPTION
same values are present at default.prop also move new values into it

Signed-off-by: David Viteri <davidteri91@gmail.com>