### PR TITLE
rhine: add missing AUDIO_DEVICE_IN_REMOTE_SUBMIX

### DIFF
--- a/rootdir/system/etc/audio_policy.conf
+++ b/rootdir/system/etc/audio_policy.conf
@@ -5,7 +5,7 @@
 global_configuration {
   attached_output_devices AUDIO_DEVICE_OUT_EARPIECE|AUDIO_DEVICE_OUT_SPEAKER|AUDIO_DEVICE_OUT_TELEPHONY_TX
   default_output_device AUDIO_DEVICE_OUT_SPEAKER
-  attached_input_devices AUDIO_DEVICE_IN_BUILTIN_MIC|AUDIO_DEVICE_IN_BACK_MIC|AUDIO_DEVICE_IN_VOICE_CALL|AUDIO_DEVICE_IN_TELEPHONY_RX
+  attached_input_devices AUDIO_DEVICE_IN_BUILTIN_MIC|AUDIO_DEVICE_IN_BACK_MIC|AUDIO_DEVICE_IN_REMOTE_SUBMIX|AUDIO_DEVICE_IN_VOICE_CALL|AUDIO_DEVICE_IN_TELEPHONY_RX
 }
 
 # audio hardware module section: contains descriptors for all audio hw modules present on the


### PR DESCRIPTION
needed for MIRACAST

Signed-off-by: David Viteri <davidteri91@gmail.com>