### PR TITLE
rhine: remove duplicate art props

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -199,10 +199,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # ART
 PRODUCT_PROPERTY_OVERRIDES += \
-    dalvik.vm.dex2oat-Xms=64m \
-    dalvik.vm.dex2oat-Xmx=512m \
-    dalvik.vm.image-dex2oat-Xms=64m \
-    dalvik.vm.image-dex2oat-Xmx=64m \
     dalvik.vm.dex2oat-filter=speed \
     dalvik.vm.image-dex2oat-filter=speed
 


### PR DESCRIPTION
those are defined in default.prop

Signed-off-by: David Viteri <davidteri91@gmail.com>