### PR TITLE
rhine: init: decrease read ahead buffer size

### DIFF
--- a/rootdir/init.rhine.rc
+++ b/rootdir/init.rhine.rc
@@ -151,8 +151,8 @@ on early-boot
 on boot
 
     # read ahead buffer
-    write /sys/block/mmcblk0/queue/read_ahead_kb 2048
-    write /sys/block/mmcblk1/queue/read_ahead_kb 2048
+    write /sys/block/mmcblk0/queue/read_ahead_kb 512
+    write /sys/block/mmcblk1/queue/read_ahead_kb 512
 
     # PM8941 flash
     chown media system /sys/class/misc/pm8941-flash/device/current1


### PR DESCRIPTION
The operating system can detect when an application is reading
data sequentially from a file or from disk.
In such cases, it performs an intelligent read-ahead algorithm,
whereby more data than is requested by the user is read from disk.

Thus, when the user next attempts to read a block of data, it will
already by in the operating system's page cache.

The potential down side to this is that the operating system can
read more data from disk than necessary, which occupies space in
the page cache until it is evicted because of high memory pressure.
Having multiple processes doing false read-ahead would increase
memory pressure in this circumstance.

So, this change reduces read_ahead_kb value from 2048 to 512 then
this setting tells the operating system not to read extra bytes,
which can increase IO time although some performance tests means
otherwise like the original patch:

    5bc4ee96ac3755c5f16a2ec6f6b674dc60d45163

Signed-off-by: Humberto Borba <humberos@gmail.com>