### PR TITLE
rhine: add sensor props

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -64,3 +64,34 @@ wifi.interface=wlan0
 
 # conceal color
 persist.vidc.dec.conceal_color=32784
+
+# sensor streaming rate
+ro.qti.sensors.max_accel_rate=false
+ro.qti.sensors.max_gyro_rate=false
+ro.qti.sensors.max_mag_rate=false
+ro.qti.sensors.max_geomag_rotv=50
+
+# optional sensor types
+ro.qti.sdk.sensors.gestures=false
+ro.qti.sensors.pedometer=false
+ro.qti.sensors.step_detector=true
+ro.qti.sensors.step_counter=true
+ro.qti.sensors.pam=false
+ro.qti.sensors.scrn_ortn=false
+ro.qti.sensors.smd=true
+ro.qti.sensors.game_rv=true
+ro.qti.sensors.georv=true
+ro.qti.sensors.cmc=false
+ro.qti.sensors.bte=false
+ro.qti.sensors.fns=false
+ro.qti.sensors.qmd=false
+ro.qti.sensors.amd=false
+ro.qti.sensors.rmd=false
+ro.qti.sensors.vmd=false
+ro.qti.sensors.gtap=false
+ro.qti.sensors.tap=false
+ro.qti.sensors.facing=false
+ro.qti.sensors.tilt=false
+ro.qti.sensors.tilt_detector=true
+ro.qti.sensors.dpc=false
+ro.qti.sensors.wu=false


### PR DESCRIPTION
those visibles and not by sensor HAL

took from all sony lollipop releases for all rhine targets

Signed-off-by: David Viteri <davidteri91@gmail.com>