### PR TITLE
Setting the default network property

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -2,6 +2,9 @@ rild.libpath=/vendor/lib/libril-qc-qmi-1.so
 rild.libargs=-d /dev/smd0
 ril.subscription.types=NV,RUIM
 
+# Default to LTE/GSM/WCDMA. B2G will rely on it to detect hw capabilities
+ro.telephony.default_network=9
+
 # system props for the data modules
 ro.use_data_netmgrd=true
 persist.data.netmgrd.qos.enable=true


### PR DESCRIPTION
This value is still being read by framework as of 5.1.1, so let's keep
it. Also, B2G relies on it to detect the hardware capabilities, so we
keep it at 9 to get LTE, WCDMA and GSM to work on devices.