### PR TITLE
rhine: correct paths for sepolicy

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -11,11 +11,11 @@
 
 /data/etc/bluetooth_bdaddr             u:object_r:addrsetup_data_file:s0
 
-/system/vendor/bin/addrsetup                  u:object_r:addrsetup_exec:s0
+/system/bin/macaddrsetup                      u:object_r:addrsetup_exec:s0
+/system/bin/thermanager                       u:object_r:thermanager_exec:s0
+/system/bin/timekeep                          u:object_r:timekeep_exec:s0
 /system/vendor/bin/sct_service                u:object_r:sct_exec:s0
 /system/vendor/bin/tad_static                 u:object_r:tad_exec:s0
 /system/vendor/bin/ta_qmi_service             u:object_r:ta_qmi_exec:s0
-/system/vendor/bin/thermanager                u:object_r:thermanager_exec:s0
-/system/vendor/bin/timekeep                   u:object_r:timekeep_exec:s0
 
 /sys/devices/fb000000.qcom,wcnss-wlan/wcnss_mac_addr    u:object_r:sysfs_addrsetup:s0


### PR DESCRIPTION
Correct and reorder logically sepolicy file paths and correct name for macaddrsetup in sepolicy/file_contexts