### PR TITLE
rhine: remove HEVC

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -120,7 +120,6 @@ PRODUCT_PACKAGES += \
     libOmxCore \
     libmm-omxcore \
     libOmxVdec \
-    libOmxVdecHevc \
     libOmxVenc
 
 #lights


### PR DESCRIPTION
that seems to be provided by manufacturers due to it isn't compiled from aosp

Signed-off-by: David Viteri <davidteri91@gmail.com>