### PR TITLE
fstab.rhine: f2fs

### DIFF
--- a/rootdir/fstab.rhine
+++ b/rootdir/fstab.rhine
@@ -2,9 +2,11 @@
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
-/dev/block/platform/msm_sdcc.1/by-name/system       /system         ext4    ro,barrier=1                                                    wait
-/dev/block/platform/msm_sdcc.1/by-name/cache        /cache          ext4    noatime,nosuid,nodev,barrier=1,data=ordered                     wait,check
-/dev/block/platform/msm_sdcc.1/by-name/userdata     /data           ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc     wait,check,encryptable=footer
+/dev/block/platform/msm_sdcc.1/by-name/system       /system         ext4    ro,barrier=1                                                                                    wait
+/dev/block/platform/msm_sdcc.1/by-name/cache        /cache          ext4    noatime,nosuid,nodev,barrier=1,data=ordered                                                     wait,check
+/dev/block/platform/msm_sdcc.1/by-name/cache        /cache          f2fs    noatime,nodiratime,nosuid,nodev,discard,inline_xattr,inline_data,inline_dentry,flush_merge      wait,check
+/dev/block/platform/msm_sdcc.1/by-name/userdata     /data           ext4    noatime,nosuid,nodev,barrier=1,data=ordered,noauto_da_alloc                                     wait,check,encryptable=footer
+/dev/block/platform/msm_sdcc.1/by-name/userdata     /data           f2fs    noatime,nodiratime,nosuid,nodev,discard,inline_xattr,inline_data,inline_dentry,flush_merge      wait,check,encryptable=footer
 /dev/block/platform/msm_sdcc.1/by-name/ramdump      /misc           emmc    defaults                                                        defaults
 /dev/block/platform/msm_sdcc.1/by-name/boot         /boot           emmc    defaults                                                        defaults
 /dev/block/platform/msm_sdcc.1/by-name/FOTAKernel   /recovery       emmc    defaults                                                        defaults


### PR DESCRIPTION
make data and cache partitions mountable