### PR TITLE
Revert "rhine: use proper black conceal color for our kernel 3.10"

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -70,6 +70,3 @@ persist.sys.wfd.virtual=0
 
 # Wi-Fi interface name
 wifi.interface=wlan0
-
-# Conceal color
-persist.vidc.dec.conceal_color=32784


### PR DESCRIPTION
This reverts commit 97ff6dcdcd823af88c1c7f8dcb061e2c79dc1639.

see: https://android.googlesource.com/platform/hardware/qcom/media/+/android-6.0.0_r1/mm-video-v4l2/vidc/vdec/src/omx_vdec_msm8974.cpp#132

Conflicts:
	system.prop