### PR TITLE
rhine: ueventd: remove deprecated camera permissions

### DIFF
--- a/rootdir/ueventd.rhine.rc
+++ b/rootdir/ueventd.rhine.rc
@@ -119,5 +119,3 @@
 /sys/devices/virtual/graphics/fb1/product_description 0664 system graphics
 /sys/devices/virtual/graphics/fb1/hdcp/tp             0664 system graphics
 /sys/devices/virtual/graphics/fb2/ad                  0664 system graphics
-/sys/devices/sony_camera_0/info                       0666 camera camera
-/sys/devices/sony_camera_1/info                       0666 camera camera


### PR DESCRIPTION
following commit: 2e8884d3ff83d9c2800bb557e98266fb976372b9

Signed-off-by: David Viteri <davidteri91@gmail.com>