### PR TITLE
rhine: ueventd: remove deprecated camera permissions

### DIFF
--- a/rootdir/ueventd.rhine.rc
+++ b/rootdir/ueventd.rhine.rc
@@ -119,5 +119,3 @@
 /sys/devices/virtual/graphics/fb1/product_description 0664 system graphics
 /sys/devices/virtual/graphics/fb1/hdcp/tp             0664 system graphics
 /sys/devices/virtual/graphics/fb2/ad                  0664 system graphics
-/sys/devices/sony_camera_0/info                       0666 camera camera
-/sys/devices/sony_camera_1/info                       0666 camera camera


### PR DESCRIPTION
following commit: c4b98464d49cd0b35d6310aa04ac7eadad343a3b

Signed-off-by: David Viteri <davidteri91@gmail.com>