### PR TITLE
rhine: Remove deprecated permission

### DIFF
--- a/rootdir/init.rhine.rc
+++ b/rootdir/init.rhine.rc
@@ -37,11 +37,6 @@ on fs
     write /sys/kernel/boot_adsp/boot 1
 
 on post-fs-data
-    # MSM specific files that need to be created on /data
-    # We will remap this as /mnt/sdcard with the sdcard fuse tool
-    mkdir /data/media 0775 media_rw media_rw
-    chown media_rw media_rw /data/media
-
     mkdir /data/misc/bluetooth 0770 bluetooth bluetooth
 
     # To observe dnsmasq.leases file for dhcp information of soft ap.


### PR DESCRIPTION
This change is part of:
https://android.googlesource.com/device/lge/hammerhead/+/38dcd1fc134a844e0e2f78b0e4e7e52a90afad79