### PR TITLE
rhine: Force dex2oat not to use swap file

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -205,6 +205,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # ART
 PRODUCT_PROPERTY_OVERRIDES += \
     dalvik.vm.dex2oat-filter=speed \
+    dalvik.vm.dex2oat-swap=false \
     dalvik.vm.image-dex2oat-filter=speed
 
 # ART


### PR DESCRIPTION
Bug: 20658562
Change-Id: Ib8e47b3edd94b1977c294959cdde01a54b64f123
Signed-off-by: Thierry Strudel <tstrudel@google.com>