### PR TITLE
Revert "rhine: fstab: Add flag to external sd mount"

### DIFF
--- a/rootdir/fstab.rhine
+++ b/rootdir/fstab.rhine
@@ -8,5 +8,5 @@
 /dev/block/platform/msm_sdcc.1/by-name/ramdump      /misc           emmc    defaults                                                        defaults
 /dev/block/platform/msm_sdcc.1/by-name/boot         /boot           emmc    defaults                                                        defaults
 /dev/block/platform/msm_sdcc.1/by-name/FOTAKernel   /recovery       emmc    defaults                                                        defaults
-/devices/msm_sdcc.2/mmc_host*                       auto            auto    nosuid,nodev                                                    voldmanaged=sdcard1:auto,noemulatedsd
+/devices/msm_sdcc.2/mmc_host*                       auto            auto    nosuid,nodev                                                    voldmanaged=sdcard1:auto
 /devices/platform/xhci-hcd                          auto            auto    nosuid,nodev                                                    voldmanaged=usbdisk:auto


### PR DESCRIPTION
Reverts sonyxperiadev/device-sony-rhine#120

according to https://source.android.com/devices/storage/config-example.html#android_6 
"noemulatedsd" flag is for physical primary only
rhine is emulated primary, physical secondary