### PR TITLE
rhine: Update audio_effects

### DIFF
--- a/rootdir/system/etc/audio_effects.conf
+++ b/rootdir/system/etc/audio_effects.conf
@@ -12,15 +12,6 @@ libraries {
   reverb {
     path /system/lib/soundfx/libreverbwrapper.so
   }
-  qcbassboost {
-    path /vendor/lib/soundfx/libqcbassboost.so
-  }
-  qcvirt {
-    path /vendor/lib/soundfx/libqcvirt.so
-  }
-  qcreverb {
-    path /vendor/lib/soundfx/libqcreverb.so
-  }
   visualizer_sw {
     path /system/lib/soundfx/libvisualizer.so
   }
@@ -30,17 +21,17 @@ libraries {
   downmix {
     path /system/lib/soundfx/libdownmix.so
   }
-  loudness_enhancer {
-    path /system/lib/soundfx/libldnhncr.so
-  }
   proxy {
     path /system/lib/soundfx/libeffectproxy.so
   }
   offload_bundle {
     path /system/lib/soundfx/libqcompostprocbundle.so
   }
-  audio_pre_processing {
+  qcom_pre_processing {
     path /system/lib/soundfx/libqcomvoiceprocessing.so
+  }
+  loudness_enhancer {
+    path /system/lib/soundfx/libldnhncr.so
   }
 }
 
@@ -94,8 +85,8 @@ effects {
     uuid 14804144-a5ee-4d24-aa88-0002a5d5c51b
 
     libsw {
-      library qcbassboost
-      uuid 23aca180-44bd-11e2-bcfd-0800200c9a66
+      library bundle
+      uuid 8631f300-72e2-11df-b57e-0002a5d5c51b
     }
 
     libhw {
@@ -108,8 +99,8 @@ effects {
     uuid d3467faa-acc7-4d34-acaf-0002a5d5c51b
 
     libsw {
-      library qcvirt
-      uuid e6c98a16-22a3-11e2-b87b-f23c91aec05e
+      library bundle
+      uuid 1d4033c0-8557-11df-9f2d-0002a5d5c51b
     }
 
     libhw {
@@ -140,8 +131,8 @@ effects {
     uuid 48404ac9-d202-4ccc-bf84-0002a5d5c51b
 
     libsw {
-      library qcreverb
-      uuid a8c1e5f3-293d-43cd-95ec-d5e26c02e217
+      library reverb
+      uuid 4a387fc0-8ab3-11df-8bad-0002a5d5c51b
     }
 
     libhw {
@@ -154,8 +145,8 @@ effects {
     uuid b707403a-a1c1-4291-9573-0002a5d5c51b
 
     libsw {
-      library qcreverb
-      uuid 791fff8b-8129-4655-83a4-59bc61034c3a
+      library reverb
+      uuid c7a511a0-a3bb-11df-860e-0002a5d5c51b
     }
 
     libhw {
@@ -168,8 +159,8 @@ effects {
     uuid 1b78f587-6d1c-422e-8b84-0002a5d5c51b
 
     libsw {
-      library qcreverb
-      uuid 53ef1db5-c0c0-445b-b060-e34d20ebb70a
+      library reverb
+      uuid f29a1400-a3bb-11df-8ddc-0002a5d5c51b
     }
 
     libhw {
@@ -182,8 +173,8 @@ effects {
     uuid f3e178d2-ebcb-408e-8357-0002a5d5c51b
 
     libsw {
-      library qcreverb
-      uuid b08a0e38-22a5-11e2-b87b-f23c91aec05e
+      library reverb
+      uuid 172cdf00-a3bc-11df-a72f-0002a5d5c51b
     }
 
     libhw {
@@ -192,18 +183,18 @@ effects {
     }
   }
   visualizer {
-#    library proxy
-#    uuid 1d0a1a53-7d5d-48f2-8e71-27fbd10d842c
+    library proxy
+    uuid ec7178ec-e5e1-4432-a3f4-4657e6795210
 
-#    libsw {
+    libsw {
       library visualizer_sw
       uuid  d069d9e0-8329-11df-9168-0002a5d5c51b
-#    }
+    }
 
-#    libhw {
-#      library visualizer_hw
-#      uuid 7a8044a0-1a71-11e3-a184-0002a5d5c51b
-#    }
+    libhw {
+      library visualizer_hw
+      uuid 7a8044a0-1a71-11e3-a184-0002a5d5c51b
+    }
   }
   downmix {
     library downmix
@@ -213,14 +204,6 @@ effects {
     library loudness_enhancer
     uuid fa415329-2034-4bea-b5dc-5b381c8d1e2c
   }
-#  aec {
-#    library audio_pre_processing
-#    uuid 0f8d0d2a-59e5-45fe-b6e4-248c8a799109
-#  }
-#  ns {
-#    library audio_pre_processing
-#    uuid 1d97bb0b-9e2f-4403-9ae3-58c2554306f8
-#  }
 }
 
 # Default pre-processing effects. Add to audio_effect.conf "effects" section if


### PR DESCRIPTION
Follow Nexus Configuration:
remove paths for (libqcbassboost.so - libqcvirt.so - libqcreverb.so)
remove paths for aec and ns
changes made for alleviate claims from AUDIO_EFFECTS_SESSION when play music due to missing libs on M libs release

Signed-off-by: David Viteri <davidteri91@gmail.com>