### PR TITLE
rhine: re-add aosp flp location provider

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -84,6 +84,8 @@
          that matches the signature of at least one package on this list.
          -->
     <string-array name="config_locationProviderPackageNames" translatable="false">
+        <!-- The standard AOSP fused location provider -->
+        <item>com.android.location.fused</item>
         <!-- The Google provider -->
         <item>com.google.android.gms</item>
     </string-array>


### PR DESCRIPTION
this is considered all the time by aosp and without this we finish with gps not working
re-add it to make it work

https://drive.google.com/file/d/0B-e5eQvKq2t2UGs2dVlYblhlSUU/view?usp=sharing

Signed-off-by: David Viteri <davidteri91@gmail.com>