### PR TITLE
rhine: disable 1080p resolution on back camera to avoid crash

### DIFF
--- a/rootdir/system/etc/media_profiles.xml
+++ b/rootdir/system/etc/media_profiles.xml
@@ -137,6 +137,7 @@
                    channels="1" />
         </EncoderProfile>
 
+        <!--
         <EncoderProfile quality="1080p" fileFormat="mp4" duration="30">
             <Video codec="h264"
                    bitRate="17000000"
@@ -148,6 +149,7 @@
                    sampleRate="48000"
                    channels="1" />
         </EncoderProfile>
+        -->
 
         <EncoderProfile quality="timelapseqcif" fileFormat="mp4" duration="30">
             <Video codec="h264"
@@ -201,18 +203,22 @@
                    channels="1" />
         </EncoderProfile>
 
+        <!--
         <EncoderProfile quality="timelapse1080p" fileFormat="mp4" duration="30">
             <Video codec="h264"
                    bitRate="17000000"
                    width="1920"
                    height="1080"
                    frameRate="30" />
+        -->
             <!-- audio setting is ignored -->
+        <!--
             <Audio codec="aac"
                    bitRate="96000"
                    sampleRate="48000"
                    channels="1" />
         </EncoderProfile>
+        -->
 
         <ImageEncoding quality="95" />
         <ImageEncoding quality="80" />


### PR DESCRIPTION
The current implementation does not support this resolution right now.

Signed-off-by: Julien Bolard <jbolard@genymobile.com>