### PR TITLE
rhine: remove vendor products

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -149,22 +149,16 @@ PRODUCT_PACKAGES += \
     wpa_supplicant \
     wpa_supplicant.conf
 
-#CAMERA
+# CAMERA
 PRODUCT_PACKAGES += \
     libmmcamera_interface \
     libmmjpeg_interface \
     libqomx_core \
     camera.msm8974
 
+# Keymaster
 PRODUCT_PACKAGES += \
     keystore.msm8974
-
-# Misc
-PRODUCT_PACKAGES += \
-    libmiscta \
-    libta \
-    tad_static \
-    ta_qmi_service
 
 # OSS
 PRODUCT_PACKAGES += \
@@ -172,9 +166,6 @@ PRODUCT_PACKAGES += \
     TimeKeep \
     thermanager \
     macaddrsetup
-
-PRODUCT_PACKAGES += \
-    rmt_storage
 
 # Charger
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
those are defined at qcom-vendor.mk in vendor files

Signed-off-by: David Viteri <davidteri91@gmail.com>