### PR TITLE
rhine: set selabel for recovery device for install_recovery to access

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -6,6 +6,7 @@
 
 # Block devices
 /dev/block/platform/msm_sdcc\.1/by-name/TA                u:object_r:trim_area_partition_device:s0
+/dev/block/platform/msm_sdcc\.1/by-name/FOTAKernel        u:object_r:recovery_block_device:s0
 
 /data/etc/bluetooth_bdaddr             u:object_r:addrsetup_data_file:s0
 


### PR DESCRIPTION
[   10.766686] type=1400 audit(1608976.449:4): avc: denied { read } for pid=312 comm=applypatch name=mmcblk0p16 dev=tmpfs ino=10558 scontext=u:r:install_recovery:s0 tcontext=u:object_r:block_device:s0 tclass=blk_file permissive=1
[   10.803486] type=1400 audit(1608976.489:5): avc: denied { open } for pid=312 comm=applypatch path=/dev/block/mmcblk0p16 dev=tmpfs ino=10558 scontext=u:r:install_recovery:s0 tcontext=u:object_r:block_device:s0 tclass=blk_file permissive=1
[   10.829274] type=1400 audit(1608976.489:6): avc: denied { getattr } for pid=312 comm=applypatch path=/dev/block/mmcblk0p16 dev=tmpfs ino=10558 scontext=u:r:install_recovery:s0 tcontext=u:object_r:block_device:s0 tclass=blk_file permissive=1

Signed-off-by: David Viteri <davidteri91@gmail.com>