### PR TITLE
rhine: update kernel headers

### DIFF
--- a/kernel-headers/linux/pn547.h
+++ b/kernel-headers/linux/pn547.h
@@ -50,4 +50,14 @@ struct pn547_i2c_platform_data {
 	bool dynamic_config;
 };
 
+#if defined(CONFIG_ARM) && defined (CONFIG_ARCH_MSM)
+int board_nfc_parse_dt(struct device *dev,
+		struct pn547_i2c_platform_data *pdata);
+int board_nfc_hw_lag_check(struct i2c_client *d,
+		struct pn547_i2c_platform_data *pdata);
+#else
+#define board_nfc_parse_dt(x, ...) 0
+#define board_nfc_hw_lag_check(x, ...) 0
+#endif
+
 #endif

--- a/kernel-headers/sound/compress_params.h
+++ b/kernel-headers/sound/compress_params.h
@@ -57,6 +57,7 @@
 #define MAX_NUM_CODECS 32
 #define MAX_NUM_CODEC_DESCRIPTORS 32
 #define MAX_NUM_BITRATES 32
+#define MAX_NUM_SAMPLE_RATES 32
 
 /* compressed TX */
 #define MAX_NUM_FRAMES_PER_BUFFER 1
@@ -262,6 +263,7 @@ struct snd_enc_wma {
 	__u32 encodeopt;
 	__u32 encodeopt1;
 	__u32 encodeopt2;
+	__u32 avg_bit_rate;
 };
 
 
@@ -361,7 +363,8 @@ union snd_codec_options {
 
 /** struct snd_codec_desc - description of codec capabilities
  * @max_ch: Maximum number of audio channels
- * @sample_rates: Sampling rates in Hz, use SNDRV_PCM_RATE_xxx for this
+ * @sample_rates: Sampling rates in Hz, use values like 48000 for this
+ * @num_sample_rates: Number of valid values in sample_rates array
  * @bit_rate: Indexed array containing supported bit rates
  * @num_bitrates: Number of valid values in bit_rate array
  * @rate_control: value is specified by SND_RATECONTROLMODE defines.
@@ -383,7 +386,8 @@ union snd_codec_options {
 
 struct snd_codec_desc {
 	__u32 max_ch;
-	__u32 sample_rates;
+	__u32 sample_rates[MAX_NUM_SAMPLE_RATES];
+	__u32 num_sample_rates;
 	__u32 bit_rate[MAX_NUM_BITRATES];
 	__u32 num_bitrates;
 	__u32 rate_control;
@@ -401,7 +405,8 @@ struct snd_codec_desc {
  * @ch_out: Number of output channels. In case of contradiction between
  *		this field and the channelMode field, the channelMode field
  *		overrides.
- * @sample_rate: Audio sample rate of input data
+ * @sample_rate: Audio sample rate of input data in Hz, use values like 48000
+ *		for this.
  * @bit_rate: Bitrate of encoded data. May be ignored by decoders
  * @rate_control: Encoding rate control. See SND_RATECONTROLMODE defines.
  *               Encoders may rely on profiles for quality levels.


### PR DESCRIPTION
reflect current LA.BF64.1.2.2_rb4.7 kernelheaders
Testbuild succeeded on Amami