### PR TITLE
rhine: Remove obsolete sepolicy define

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -56,5 +56,3 @@ BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR := device/sony/rhine/bluetooth
 BOARD_HAVE_BLUETOOTH := true
 BOARD_HAVE_BLUETOOTH_QCOM := true
 
-# SELinux
-BOARD_SEPOLICY_DIRS += device/sony/rhine/sepolicy


### PR DESCRIPTION
No longer needed, moved to device-sony-common.