### PR TITLE
recovery: add missing symlink

### DIFF
--- a/rootdir/init.recovery.rhine.rc
+++ b/rootdir/init.recovery.rhine.rc
@@ -1,3 +1,6 @@
+on init
+   symlink /dev/block/platform/msm_sdcc.1 /dev/block/bootdevice
+
 on boot
     write /sys/class/android_usb/android0/idVendor 0FCE
     write /sys/class/android_usb/android0/idProduct 6${ro.usb.pid_suffix}


### PR DESCRIPTION
link to /dev/block/bootdevice else in recovery partitions are not mountable.

tested on TWRP recovery