### PR TITLE
Rhine: add simple cpuquiet / rqbalance permissions

### DIFF
--- a/rootdir/init.rhine.pwr.rc
+++ b/rootdir/init.rhine.pwr.rc
@@ -53,6 +53,14 @@ on boot
     write /sys/devices/system/cpu/cpu2/online 1
     write /sys/devices/system/cpu/cpu3/online 1
 
+    # cpuquiet rqbalance permissions
+    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
+    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
+    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds
+
 on property:init.svc.bootanim=stopped
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "interactive"
     write /sys/devices/system/cpu/cpu1/cpufreq/scaling_governor "interactive"

--- a/rootdir/ueventd.rhine.rc
+++ b/rootdir/ueventd.rhine.rc
@@ -119,3 +119,8 @@
 /sys/devices/virtual/graphics/fb1/product_description 0664 system graphics
 /sys/devices/virtual/graphics/fb1/hdcp/tp             0664 system graphics
 /sys/devices/virtual/graphics/fb2/ad                  0664 system graphics
+
+# cpuquiet rqbalance permissions
+/sys/devices/system/cpu/cpuquiet/rqbalance/balance_level             0660 system system
+/sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds         0660 system system
+/sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds    0660 system system


### PR DESCRIPTION
as suggested in: https://github.com/sonyxperiadev/device-sony-common/pull/42