### PR TITLE
rhine: Fix simple power HAL permissions

### DIFF
--- a/rootdir/init.rhine.pwr.rc
+++ b/rootdir/init.rhine.pwr.rc
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+on init
+    # cpuquiet rqbalance permissions
+    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
+    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
+    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds
+
 on charger
     # Enable Power modes and set the CPU Freq Sampling rates
     write /sys/module/msm_thermal/core_control/enabled 0
@@ -52,14 +61,6 @@ on boot
     write /sys/devices/system/cpu/cpu1/online 1
     write /sys/devices/system/cpu/cpu2/online 1
     write /sys/devices/system/cpu/cpu3/online 1
-
-    # cpuquiet rqbalance permissions
-    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
-    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
-    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
-    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
-    chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds
-    chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds
 
 on property:init.svc.bootanim=stopped
     write /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor "interactive"


### PR DESCRIPTION
    Fix and move simple power HAL permissions to "on init" stage
    then it will also be able early to LPM mode.

    Fix:

    05-16 10:39:00.817  1027  1048 I Simple PowerHAL: Device is asleep.
    05-16 10:39:00.817  1027  1048 I Simple PowerHAL: Setting low power
mode
    05-16 10:39:00.817  1027  1048 E Simple PowerHAL: Error opening
/sys/devices/system/cpu/cpuquiet/rqbalance/balance_level: Permission
denied
    05-16 10:39:00.817  1027  1048 E Simple PowerHAL: Error opening
/sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds: Permission
denied
    05-16 10:39:00.817  1027  1048 E Simple PowerHAL: Error opening
/sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds:
Permission denied