### PR TITLE
Rhine: Build Stk

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -93,6 +93,10 @@ PRODUCT_PACKAGES += \
     qcom.fmradio \
     FMRadio
 
+# SimToolKit
+PRODUCT_PACKAGES += \
+    Stk
+
 # RILD
 PRODUCT_PROPERTY_OVERRIDES += \
     rild.libpath=/vendor/lib/libril-qc-qmi-1.so \


### PR DESCRIPTION
there is not windy device in rhine family so it can be defined in rhine-common

Signed-off-by: David Viteri <davidteri91@gmail.com>