### PR TITLE
Move sysfs and props for cpuquiet hotplugging

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -65,6 +65,9 @@ BOARD_HAVE_BLUETOOTH_QCOM := true
 BOARD_HAVE_QCOM_FM := true
 TARGET_QCOM_NO_FM_FIRMWARE := true
 
+# Props for hotplugging
+TARGET_SYSTEM_PROP += device/sony/rhine/system.prop
+
 # SELinux
 BOARD_SEPOLICY_DIRS += device/sony/rhine/sepolicy
 

--- a/rootdir/init.rhine.pwr.rc
+++ b/rootdir/init.rhine.pwr.rc
@@ -14,9 +14,15 @@
 
 on init
     # cpuquiet rqbalance permissions
+    chown system system /sys/devices/system/cpu/cpuquiet/nr_min_cpus
+    chown system system /sys/devices/system/cpu/cpuquiet/nr_power_max_cpus
+    chown system system /sys/devices/system/cpu/cpuquiet/nr_thermal_max_cpus
     chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
     chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
     chown system system /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/nr_min_cpus
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/nr_power_max_cpus
+    chmod 0660 /sys/devices/system/cpu/cpuquiet/nr_thermal_max_cpus
     chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level
     chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds
     chmod 0660 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds

--- a/rootdir/ueventd.rhine.rc
+++ b/rootdir/ueventd.rhine.rc
@@ -121,6 +121,9 @@
 /sys/devices/virtual/graphics/fb2/ad                  0664 system graphics
 
 # cpuquiet rqbalance permissions
+/sys/devices/system/cpu/cpuquiet/nr_min_cpus                         0660 system system
+/sys/devices/system/cpu/cpuquiet/nr_power_max_cpus                   0660 system system
+/sys/devices/system/cpu/cpuquiet/nr_thermal_max_cpus                 0660 system system
 /sys/devices/system/cpu/cpuquiet/rqbalance/balance_level             0660 system system
 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_run_thresholds         0660 system system
 /sys/devices/system/cpu/cpuquiet/rqbalance/nr_down_run_thresholds    0660 system system

--- a/system.prop
+++ b/system.prop
@@ -1,0 +1,15 @@
+#
+# rqbalance specific values
+#
+
+cpuquiet.low.min_cpus=1
+cpuquiet.low.max_cpus=2
+rqbalance.low.balance_level=80
+rqbalance.low.up_threshold=200 450 550 580 600 640 750 4294967295
+rqbalance.low.down_threshold=0 120 320 400 440 500 550 700
+
+cpuquiet.normal.min_cpus=2
+cpuquiet.normal.max_cpus=4
+rqbalance.normal.balance_level=40
+rqbalance.normal.up_threshold=100 300 400 500 525 600 700 4294967295
+rqbalance.normal.down_threshold=0 100 300 400 425 500 600 650


### PR DESCRIPTION
Core limiting via msm_performance works well, but cpuquiet absolutely
hates it. rqbalance is not aware of msm_performance so it spams dmesg
because it cannot online a core for 'unknown' reasons.

We can achieve the same result using cpuquiet which rqbalance is
aware of. We can also have two sources of core limiting, power
profile and thermal.

We also need to tune rqbalance and cpuquiet per platform so also
move their system props.

Signed-off-by: Adam Farden <adam@farden.cz>