### PR TITLE
rhine: remove uneeded nfc devices

### DIFF
--- a/rootdir/ueventd.rhine.rc
+++ b/rootdir/ueventd.rhine.rc
@@ -101,9 +101,7 @@
 /dev/wcnss_ctrl           0660   system     system
 
 # NFC
-/dev/nfc-nci              0660   nfc        nfc
 /dev/pn544                0660   nfc        nfc
-/dev/pn547                0660   nfc        nfc
 
 # LED
 /sys/devices/01-qcom,leds-d000/leds/led:* max_brightness          0664 system system


### PR DESCRIPTION
those are not present here also rhine has only pn544 chip

Signed-off-by: David Viteri <davidteri91@gmail.com>