### PR TITLE
rhine: Fix LED paths for kernel 1.3.3

### DIFF
--- a/rootdir/ueventd.rhine.rc
+++ b/rootdir/ueventd.rhine.rc
@@ -106,13 +106,15 @@
 /dev/pn544                0660   nfc        nfc
 
 # LED
-/sys/devices/01-qcom,leds-d000/leds/led:* max_brightness          0664 system system
-/sys/devices/01-qcom,leds-d000/leds/led:* brightness              0664 system system
-/sys/devices/01-qcom,leds-d000/leds/led:* blink                   0664 system system
-/sys/devices/01-qcom,leds-d000/leds/led:* duty_pcts               0664 system system
-/sys/devices/01-qcom,leds-d000/leds/led:* ramp_step_ms            0664 system system
-/sys/devices/01-qcom,leds-d800/leds/wled:backlight max_brightness 0664 system system
-/sys/devices/01-qcom,leds-d800/leds/wled:backlight brightness     0664 system system
+/sys/devices/01-qcom,leds-0x0000d000/leds/led:* max_brightness          0664 system system
+/sys/devices/01-qcom,leds-0x0000d000/leds/led:* brightness              0664 system system
+/sys/devices/01-qcom,leds-0x0000d000/leds/led:* blink                   0664 system system
+/sys/devices/01-qcom,leds-0x0000d000/leds/led:* duty_pcts               0664 system system
+/sys/devices/01-qcom,leds-0x0000d000/leds/led:* ramp_step_ms            0664 system system
+/sys/devices/01-qcom,leds-0x0000d800/leds/wled:backlight max_brightness 0664 system system
+/sys/devices/01-qcom,leds-0x0000d800/leds/wled:backlight brightness     0664 system system
+/sys/class/leds/lcd-backlight/max_brightness                            0644 root system
+/sys/class/leds/lcd-backlight/brightness                                0664 system system
 
 # Graphics Permissions
 /sys/devices/virtual/graphics/fb1/avi_itc             0664 system graphics


### PR DESCRIPTION
Signed-off-by: David Viteri <davidteri91@gmail.com>