### PR TITLE
[RHINE] system.prop: Tune rqbalance parameters

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -5,11 +5,11 @@
 cpuquiet.low.min_cpus=1
 cpuquiet.low.max_cpus=2
 rqbalance.low.balance_level=80
-rqbalance.low.up_threshold=200 450 550 580 600 640 750 4294967295
-rqbalance.low.down_threshold=0 120 320 400 440 500 550 700
+rqbalance.low.up_threshold=200 400 600 4294967295
+rqbalance.low.down_threshold=0 100 300 500
 
 cpuquiet.normal.min_cpus=2
 cpuquiet.normal.max_cpus=4
 rqbalance.normal.balance_level=40
-rqbalance.normal.up_threshold=100 300 400 500 525 600 700 4294967295
-rqbalance.normal.down_threshold=0 100 300 400 425 500 600 650
+rqbalance.normal.up_threshold=100 250 330 4294967295
+rqbalance.normal.down_threshold=0 130 220 300


### PR DESCRIPTION
Tune rqbalance to linearize CPU hotplugging and optimize power
consumption while retaining performance.