### PR TITLE
rhine: Add support for top-app cpuset

### DIFF
--- a/rootdir/init.rhine.rc
+++ b/rootdir/init.rhine.rc
@@ -37,10 +37,12 @@ on boot
     chmod 0664 /dev/cpuset/camera-daemon/tasks
 
     # update foreground cpuset now that processors are up
-    write /dev/cpuset/foreground/cpus 0-3
+    # reserve CPU 3 for the top app
+    write /dev/cpuset/foreground/cpus 0-2
     write /dev/cpuset/foreground/boost/cpus 0-3
     write /dev/cpuset/background/cpus 0
     write /dev/cpuset/system-background/cpus 0-1
+    write /dev/cpuset/top-app/cpus 0-3
 
 # OSS WLAN and BT MAC setup
 service macaddrsetup /system/bin/macaddrsetup /sys/devices/fb000000.qcom,wcnss-wlan/wcnss_mac_addr


### PR DESCRIPTION
Following kitakami: https://github.com/sonyxperiadev/device-sony-kitakami/commit/f945af43f8e70edb46f20b33dcae0ec10e6249da

Signed-off-by: David Viteri <davidteri91@gmail.com>