### PR TITLE
Fix video recording freeze bug in camera

### DIFF
--- a/rootdir/system/etc/media_profiles.xml
+++ b/rootdir/system/etc/media_profiles.xml
@@ -127,7 +127,6 @@
                    channels="1" />
         </EncoderProfile>
 
-        <!--
         <EncoderProfile quality="1080p" fileFormat="mp4" duration="30">
             <Video codec="h264"
                    bitRate="17000000"
@@ -139,7 +138,6 @@
                    sampleRate="48000"
                    channels="1" />
         </EncoderProfile>
-        -->
 
         <EncoderProfile quality="timelapseqcif" fileFormat="mp4" duration="30">
             <Video codec="h264"
@@ -193,22 +191,18 @@
                    channels="1" />
         </EncoderProfile>
 
-        <!--
         <EncoderProfile quality="timelapse1080p" fileFormat="mp4" duration="30">
             <Video codec="h264"
                    bitRate="17000000"
                    width="1920"
                    height="1080"
                    frameRate="30" />
-        -->
             <!-- audio setting is ignored -->
-        <!--
             <Audio codec="aac"
                    bitRate="96000"
                    sampleRate="48000"
                    channels="1" />
         </EncoderProfile>
-        -->
 
         <ImageEncoding quality="95" />
         <ImageEncoding quality="80" />
@@ -267,7 +261,6 @@
                    channels="1" />
         </EncoderProfile>
 
-        <!--
         <EncoderProfile quality="1080p" fileFormat="mp4" duration="30">
             <Video codec="h264"
                    bitRate="17000000"
@@ -279,7 +272,6 @@
                    sampleRate="48000"
                    channels="1" />
         </EncoderProfile>
-        -->
 
         <EncoderProfile quality="timelapseqcif" fileFormat="mp4" duration="30">
             <Video codec="h264"
@@ -333,22 +325,18 @@
                    channels="1" />
         </EncoderProfile>
 
-        <!--
         <EncoderProfile quality="timelapse1080p" fileFormat="mp4" duration="30">
             <Video codec="h264"
                    bitRate="17000000"
                    width="1920"
                    height="1080"
                    frameRate="30" />
-        -->
             <!-- audio setting is ignored -->
-        <!--
             <Audio codec="aac"
                    bitRate="96000"
                    sampleRate="48000"
                    channels="1" />
         </EncoderProfile>
-        -->
 
         <ImageEncoding quality="95" />
         <ImageEncoding quality="80" />


### PR DESCRIPTION
Re enable 1080p resolution to avoid freezing while recording videos.