### PR TITLE
rhine: use HAL1 for 8974

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -137,3 +137,8 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.qti.sensors.tilt_detector=false \
     ro.qti.sensors.dpc=false \
     ro.qti.sensors.wu=false
+
+# Override HAL from common
+## use HAL1 for 8974
+PRODUCT_DEFAULT_PROPERTY_OVERRIDES += \
+    persist.camera.HAL3.enabled=0


### PR DESCRIPTION
HAL3 has not preview

Signed-off-by: David Viteri <davidteri91@gmail.com>