### PR TITLE
rhine: init: Fix "Bad address" on write to /dev/wcnss_wlan

### DIFF
--- a/rootdir/init.rhine.rc
+++ b/rootdir/init.rhine.rc
@@ -29,7 +29,7 @@ on boot
     chown system system /sys/devices/fb000000.qcom,wcnss-wlan/wcnss_mac_addr
 
     # WCNSS enable
-    write /dev/wcnss_wlan 1
+    write /dev/wcnss_wlan ""
 
     # add a cpuset for the camera daemon
     mkdir /dev/cpuset/camera-daemon


### PR DESCRIPTION
The kernel driver expect the first write to /dev/wcnss_wlan to be
exactly 4 bytes in size and returns -EFAULT if the size is different,
which then causes noise in the kernel log:

    [   12.811828] init: write_file: Unable
     to write to '/dev/wcnss_wlan': Bad address

Writing an empty string (which actually avoids the write() syscall) is
enough (the first open() activates the wlan driver)

Change-Id: If4433036696a263651da2a251e65bce00d04a34a
Signed-off-by: Kalpaj Chaudhari <daedroza@gmail.com>