### PR TITLE
rhine: ueventd: Add common lights sysfs path

### DIFF
--- a/rootdir/ueventd.rhine.rc
+++ b/rootdir/ueventd.rhine.rc
@@ -116,6 +116,8 @@
 /sys/devices/01-qcom,leds-d000/leds/led:* ramp_step_ms            0664 system system
 /sys/devices/01-qcom,leds-d800/leds/wled:backlight max_brightness 0664 system system
 /sys/devices/01-qcom,leds-d800/leds/wled:backlight brightness     0664 system system
+/sys/class/leds/lcd-backlight/max_brightness                      0644 root system
+/sys/class/leds/lcd-backlight/brightness                          0664 system system
 
 # Graphics Permissions
 /sys/devices/virtual/graphics/fb1/avi_itc             0664 system graphics


### PR DESCRIPTION
to match common lcd brightness and max_brightness

Signed-off-by: David Viteri <davidteri91@gmail.com>