### PR TITLE
rhine: ueventd: Add common lights sysfs path

### DIFF
--- a/rootdir/ueventd.rhine.rc
+++ b/rootdir/ueventd.rhine.rc
@@ -116,6 +116,8 @@
 /sys/devices/01-qcom,leds-d000/leds/led:* ramp_step_ms            0664 system system
 /sys/devices/01-qcom,leds-d800/leds/wled:backlight max_brightness 0664 system system
 /sys/devices/01-qcom,leds-d800/leds/wled:backlight brightness     0664 system system
+/sys/class/leds/lcd-backlight/max_brightness                      0644 root system
+/sys/class/leds/lcd-backlight/brightness                          0664 system system
 
 # Graphics Permissions
 /sys/devices/virtual/graphics/fb1/avi_itc             0664 system graphics


### PR DESCRIPTION
match common lcd brightness and max_brightness
https://github.com/SonyAosp/device_sony_common/blob/android-7.1/liblights/lights.c#L58
https://github.com/SonyAosp/device_sony_common/blob/android-7.1/liblights/lights.c#L61

Signed-off-by: David Viteri <davidteri91@gmail.com>