### PR TITLE
rhine: add missing nfc_extras permission

### DIFF
--- a/platform.mk
+++ b/platform.mk
@@ -46,7 +46,8 @@ PRODUCT_COPY_FILES += \
 
 # Device Specific Hardware
 PRODUCT_COPY_FILES += \
-    frameworks/native/data/etc/com.nxp.mifare.xml:system/etc/permissions/com.nxp.mifare.xml
+    frameworks/native/data/etc/com.nxp.mifare.xml:system/etc/permissions/com.nxp.mifare.xml \
+    frameworks/native/data/etc/com.android.nfc_extras.xml:system/etc/permissions/com.android.nfc_extras.xml
 
 # Platform Init
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
needed for com.android.nfc_extras package

Signed-off-by: David Viteri <davidteri91@gmail.com>