### PR TITLE
Revert "rhine: enable legacy camera fixes"

### DIFF
--- a/PlatformConfig.mk
+++ b/PlatformConfig.mk
@@ -47,9 +47,6 @@ BOARD_FLASH_BLOCK_SIZE := 131072
 
 TARGET_RECOVERY_FSTAB = $(PLATFORM_COMMON_PATH)/rootdir/fstab.rhine
 
-# Camera HAL1 hack on 7.x
-TARGET_HAS_LEGACY_CAMERA_HAL1 := true
-
 # Wi-Fi definitions for Qualcomm solution
 BOARD_HAS_QCOM_WLAN := true
 BOARD_HOSTAPD_DRIVER := NL80211

--- a/platform.mk
+++ b/platform.mk
@@ -97,11 +97,6 @@ PRODUCT_PACKAGES += \
     InCallUI \
     Stk
 
-# Camera HAL1 hack on 7.x
-PRODUCT_PROPERTY_OVERRIDES += \
-    media.stagefright.legacyencoder=true \
-    media.stagefright.less-secure=true
-
 # RILD
 PRODUCT_PROPERTY_OVERRIDES += \
     rild.libpath=/vendor/lib/libril-qc-qmi-1.so \


### PR DESCRIPTION
This reverts commit 75cfad7776f04fac3c335f4ac86becc438c384ad.

This was moved to common